### PR TITLE
add optional rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ keywords = ["async", "coordinates", "nominatim", "geocoding", "location"]
 categories = ["api-bindings", "asynchronous"]
 license = "MIT"
 
+[features]
+default = ["reqwest/default-tls"]
+
+# Enables common rustls code.
+rustls = ["reqwest/__rustls"]
+
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 url = "2.3"
 


### PR DESCRIPTION
This feature allows to build projects without `openssl` and use `rustls` instead