### PR TITLE
Update rustls feature to more general

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [features]
 default = ["reqwest/default-tls"]
-rustls = ["reqwest/__rustls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }


### PR DESCRIPTION
https://docs.rs/reqwest/latest/reqwest/#optional-features
Enables TLS functionality provided by rustls, while using root certificates from the webpki-roots crate.