### PR TITLE
Allow instantiation of client with URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ let client = Client::new(IdentificationMethod::from_user_agent(
 ```rust no_run
 let status = client.status().await.unwrap();
 
-println!("{}", client.status().await.unwrap());
+println!("{:?}", status);
 ```
 
 Returns:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,20 @@ impl Client {
         }
     }
 
+    pub fn with_url(ident: IdentificationMethod, url: Url) -> Self {
+        let timeout = Duration::from_secs(10);
+
+        Self {
+            ident,
+            base_url: url,
+            client: reqwest::ClientBuilder::new()
+                .timeout(timeout)
+                .build()
+                .unwrap(),
+            timeout,
+        }
+    }
+
     /// Set the client's internal base url for all requests.
     pub fn set_base_url<U: TryInto<Url>>(&mut self, url: U) -> Result<(), U::Error> {
         self.base_url = url.try_into()?;


### PR DESCRIPTION
Makes the client usable even if "https://nominatim.openstreetmap.org/" is down and available to use against self-hosted instances