### PR TITLE
Ability to use wasm http requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "asynchronous"]
 license = "MIT"
 
 [features]
-# default = ["reqwest"]
+default = ["reqwest"]
 reqwest = ["dep:reqwest", "reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 wasm = ["dep:gloo"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ categories = ["api-bindings", "asynchronous"]
 license = "MIT"
 
 [features]
-default = ["reqwest/default-tls"]
+# default = ["reqwest"]
+reqwest = ["dep:reqwest", "reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
+wasm = ["dep:gloo"]
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.11", features = ["json"], default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 url = "2.4"
+gloo = { version = "0.11", features = ["net"], default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.20", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ reqwest = { version = "0.11", features = ["json"], default-features = false, opt
 serde = { version = "1.0", features = ["derive"] }
 url = "2.4"
 gloo = { version = "0.11", features = ["net"], default-features = false, optional = true }
+urlencoding = "2.1.3"
+serde_urlencoded = "0.7.1"
 
 [dev-dependencies]
 tokio = { version = "1.20", features = ["full"] }

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -6,17 +6,17 @@ pub enum IdentificationMethod {
 }
 
 impl IdentificationMethod {
-    pub fn header(&self) -> String {
+    pub fn header(&self) -> &'static str {
         match self {
-            Self::Referer(_) => "Referer".to_string(),
-            Self::UserAgent(_) => "User-Agent".to_string(),
+            Self::Referer(_) => "Referer",
+            Self::UserAgent(_) => "User-Agent",
         }
     }
 
-    pub fn value(&self) -> String {
+    pub fn value(self) -> String {
         match self {
-            Self::Referer(value) => value.to_string(),
-            Self::UserAgent(value) => value.to_string(),
+            Self::Referer(value) => value,
+            Self::UserAgent(value) => value,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,25 +312,25 @@ where
 pub struct StructuredSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    amenity: Option<String>,
+    pub amenity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    street: Option<String>,
+    pub street: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    city: Option<String>,
+    pub city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    county: Option<String>,
+    pub county: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    state: Option<String>,
+    pub state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    country: Option<String>,
+    pub country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    postalcode: Option<String>,
+    pub postalcode: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, Default, Ord, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ type HttpClient = reqwest::Client;
 type HttpClient = ();
 
 #[cfg(feature = "reqwest")]
-type Error = reqwest::Error;
+pub type Error = reqwest::Error;
 #[cfg(feature = "wasm")]
-type Error = net::Error;
+pub type Error = net::Error;
 
 
 /// The interface for accessing a Nominatim API server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,9 +213,18 @@ pub struct Place {
 /// An address for a place.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Address {
+    pub floor: Option<String>,
+    pub flats: Option<String>,
+    pub house_number: Option<String>,
+    pub street: Option<String>,
+    pub road: Option<String>,
+    pub suburb: Option<String>,
+    pub neighbourhood: Option<String>,
+    pub village: Option<String>,
     pub city: Option<String>,
     pub state_district: Option<String>,
     pub state: Option<String>,
+    pub province: Option<String>,
     #[serde(rename = "ISO3166-2-lvl4")]
     pub iso3166_2_lvl4: Option<String>,
     pub postcode: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl Client {
         let mut url = self.base_url.join("status.php").unwrap();
         url.set_query(Some("format=json"));
 
-        let headers = mk_headers(&self.ident);
+        let headers = mk_headers(self.ident.clone());
 
         fetch(&self.client, url, self.timeout, headers).await
     }
@@ -87,7 +87,7 @@ impl Client {
             query.as_ref().replace(' ', "+")
         )));
 
-        let headers = mk_headers(&self.ident);
+        let headers = mk_headers(self.ident.clone());
 
         fetch(&self.client, url, self.timeout, headers).await
     }
@@ -121,7 +121,7 @@ impl Client {
             }
         }
 
-        let headers = mk_headers(&self.ident);
+        let headers = mk_headers(self.ident.clone());
 
         fetch(&self.client, url, self.timeout, headers).await
     }
@@ -138,7 +138,7 @@ impl Client {
             queries
         )));
 
-        let headers = mk_headers(&self.ident);
+        let headers = mk_headers(self.ident.clone());
 
         fetch(&self.client, url, self.timeout, headers).await
     }
@@ -207,10 +207,10 @@ pub struct ExtraTags {
 }
 
 #[cfg(feature = "reqwest")]
-fn mk_headers(ident: &IdentificationMethod) -> HeaderMap {
+fn mk_headers(ident: IdentificationMethod) -> HeaderMap {
     let mut hs = HeaderMap::new();
     hs.append(
-        HeaderName::from_str(&ident.header())
+        HeaderName::from_str(ident.header())
             .expect("invalid nominatim auth header name"),
         HeaderValue::from_str(&ident.value())
             .expect("invalid nominatim auth header value"),
@@ -218,10 +218,10 @@ fn mk_headers(ident: &IdentificationMethod) -> HeaderMap {
     hs
 }
 #[cfg(feature = "wasm")]
-fn mk_headers(ident: &IdentificationMethod) -> Headers {
+fn mk_headers(ident: IdentificationMethod) -> Headers {
     let hs = Headers::new();
     hs.append(
-        &ident.header(),
+        ident.header(),
         &ident.value(),
     );
     hs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod ident;
 pub use ident::IdentificationMethod;
 
 #[cfg(all(feature = "reqwest", feature = "wasm"))]
-compile_error!("Features \"reqwest\" and \"wasm\" are mutually exclusive");
+compile_error!("Features \"reqwest\" and \"wasm\" are mutually exclusive - did you forget to disable default features for nominatim?");
 
 #[cfg(feature = "reqwest")]
 type HttpClient = reqwest::Client;


### PR DESCRIPTION
Hello!

I really like this crate - it's very useful for fetching data from the Nominatim API. However, I'd like to use this library exclusively in WASM. I'm submitting this PR as a proof-of-concept for how it could work - by using feature flags and `#[cfg(...)]`, we can match on the dependencies we'd need in either platform.

Please let me know what you think!